### PR TITLE
Update Dockerfile to use Docker Hardened Images (DHI)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
 #syntax=docker/dockerfile:1
 
-# Use the official Node.js image from the Docker Hub
-FROM node:latest
-
-# Set the working directory inside the container
+# === Build stage: Install dependencies and build application ===
+FROM docker/dhi-node:24.3.0-alpine3.21-dev AS builder
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-
-# Install dependencies
 RUN npm install
 
-# Copy the application code
 COPY . .
 
-# Command to run the Node.js application
+# === Final stage: Create minimal runtime image ===
+FROM docker/dhi-node:24.3.0-alpine3.21
+ENV PATH=/app/node_modules/.bin:$PATH
+
+COPY --from=builder --chown=node:node /usr/src/app /app
+WORKDIR /app
+
 CMD ["node", "index.js"]


### PR DESCRIPTION
This PR updates the Dockerfile to use Docker Hardened Images (DHI) for improved security and reduced vulnerabilities. The following changes were made:

- Replaced `node:latest` with `docker/dhi-node:24.3.0-alpine3.21-dev` for the build stage.
- Used `docker/dhi-node:24.3.0-alpine3.21` for the runtime stage.
- Implemented a multi-stage build to ensure a minimal and secure final image.

The updated image has been audited, and no vulnerabilities were detected.